### PR TITLE
Fix hook description lookup

### DIFF
--- a/src/pre_commit_starter/generator/hooks/hook_registry.py
+++ b/src/pre_commit_starter/generator/hooks/hook_registry.py
@@ -380,7 +380,7 @@ class HookRegistry:
 
     def get_hook_description(self, hook_id: str) -> str:
         """Get the description of a hook."""
-        return self._hooks.get(hook_id, {}).get("description", "")
+        return self.HOOK_DESCRIPTIONS.get(hook_id, "")
 
     def get_hook_ids_for_tech(self, tech: str) -> list[str]:
         """Get all hook IDs available for a technology.

--- a/src/tests/test_yaml_builder.py
+++ b/src/tests/test_yaml_builder.py
@@ -413,3 +413,10 @@ def test_blank_line_between_repos():
             f"No blank line between - repo: entries at lines {idx1 + 1} and {idx2 + 1}.\n"
             "YAML output:\n" + "\n".join(lines)
         )
+
+
+def test_get_hook_description():
+    """Ensure descriptions are returned for known hooks."""
+    registry = HookRegistry()
+    assert registry.get_hook_description("ruff") == "Lint Python code using Ruff"
+    assert registry.get_hook_description("unknown") == ""


### PR DESCRIPTION
## Summary
- fix HookRegistry.get_hook_description to consult HOOK_DESCRIPTIONS
- add unit test verifying descriptions

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f5872cadc8320a93eb1cf6be2ed2b