### PR TITLE
Add type hints to CLI and script

### DIFF
--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 
 
-def get_latest_tag():
+def get_latest_tag() -> str | None:
     """Get the latest git tag."""
     try:
         return subprocess.check_output(
@@ -17,7 +17,7 @@ def get_latest_tag():
         return None
 
 
-def get_commits_since_tag(tag=None):
+def get_commits_since_tag(tag: str | None = None) -> list[str]:
     """Get all commits since the specified tag."""
     cmd = ["git", "log", "--pretty=format:%s|%h|%an|%ad", "--date=short"]
     if tag:
@@ -27,7 +27,7 @@ def get_commits_since_tag(tag=None):
     return output.strip().split("\n")
 
 
-def parse_commit(commit_line):
+def parse_commit(commit_line: str) -> dict | None:
     """Parse a commit line into its components."""
     try:
         message, hash_id, author, date = commit_line.split("|")
@@ -56,7 +56,7 @@ def parse_commit(commit_line):
         return None
 
 
-def group_commits(commits):
+def group_commits(commits: list[dict | None]) -> dict[str, list[dict]]:
     """Group commits by type."""
     groups = {
         "feat": [],
@@ -79,7 +79,7 @@ def group_commits(commits):
     return groups
 
 
-def generate_changelog(tag=None):
+def generate_changelog(tag: str | None = None) -> str:
     """Generate changelog content."""
     commits = get_commits_since_tag(tag)
     parsed_commits = [parse_commit(c) for c in commits if c]
@@ -114,7 +114,7 @@ def generate_changelog(tag=None):
     return "\n".join(content)
 
 
-def main():
+def main() -> None:
     """Main function."""
     changelog_path = Path("CHANGELOG.md")
     tag = get_latest_tag()

--- a/src/pre_commit_starter/main.py
+++ b/src/pre_commit_starter/main.py
@@ -18,7 +18,7 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 
-from .detector.file_scanner import FileScanner
+from .detector.file_scanner import FileScanner, TechInfo
 from .generator.hooks.hook_registry import HookRegistry
 from .generator.yaml_builder import YAMLBuilder
 
@@ -51,7 +51,7 @@ INTERACTIVE_HELP = """
 console = Console()
 
 
-def display_summary(detected_techs: dict):
+def display_summary(detected_techs: dict) -> None:
     """Display a summary of detected technologies and proposed hooks."""
     table = Table(title="Detected Technologies")
     table.add_column("Technology", style="cyan")
@@ -82,7 +82,7 @@ def display_summary(detected_techs: dict):
     console.print(table)
 
 
-def display_hooks_for_tech(tech: str, hook_registry: HookRegistry):
+def display_hooks_for_tech(tech: str, hook_registry: HookRegistry) -> None:
     """Display hooks available for a technology."""
     hook_ids = hook_registry.get_hook_ids_for_tech(tech)
 
@@ -103,7 +103,7 @@ def display_hooks_for_tech(tech: str, hook_registry: HookRegistry):
     console.print(table)
 
 
-def select_technologies(detected_techs: dict, hook_registry: HookRegistry) -> list:
+def select_technologies(detected_techs: dict, hook_registry: HookRegistry) -> list[TechInfo]:
     """Interactive mode: Allow user to select which technologies to include hooks for."""
     if not detected_techs:
         return []
@@ -151,14 +151,14 @@ def select_technologies(detected_techs: dict, hook_registry: HookRegistry) -> li
     return selected_techs
 
 
-def display_configuration(config: str):
+def display_configuration(config: str) -> None:
     """Display the generated configuration."""
     console.print("\n[bold]Generated Configuration:[/bold]")
     syntax = Syntax(config, "yaml", theme="monokai", line_numbers=True)
     console.print(syntax)
 
 
-def display_next_steps():
+def display_next_steps() -> None:
     """Display next steps for the user."""
     console.print("\n[bold]Next steps:[/bold]")
     steps = """
@@ -246,7 +246,7 @@ def load_custom_hooks(repo_path: Path) -> dict | None:
     return result
 
 
-def run_generation(args: argparse.Namespace):
+def run_generation(args: argparse.Namespace) -> None:
     """Main logic for scanning and generating the config."""
     try:
         repo_path = Path(args.path).resolve()
@@ -368,7 +368,7 @@ def run_generation(args: argparse.Namespace):
         console.print(f"[red]Error: {e!s}[/red]")
 
 
-def main():
+def main() -> None:
     """Main function for the pre-commit-starter CLI tool."""
     parser = argparse.ArgumentParser(
         description="Generate pre-commit configuration based on repository content."


### PR DESCRIPTION
## Summary
- add `TechInfo` import for type hints
- specify return types for main CLI helpers
- add function annotations in `generate_changelog.py`

## Testing
- `pre-commit run --files src/pre_commit_starter/main.py scripts/generate_changelog.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f696dcef88320867afdc4acf11b41