### PR TITLE
Add release wrapper target and tag-only binary build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Run tests
         run: cargo test
 
-      - name: Build
-        run: cargo build --release
-
   build-wheels:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,27 @@ permissions:
   id-token: write
 
 jobs:
+  build-binary:
+    name: Build binary (linux x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build release binary
+        run: |
+          cargo build --release
+          mkdir -p dist
+          tar -czf dist/pre-commit-template-linux-x86_64.tar.gz -C target/release pre-commit-template
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: binary-linux-x86_64
+          path: dist/pre-commit-template-linux-x86_64.tar.gz
+
   build-wheels:
     name: Build wheels on ${{ matrix.platform.target }}
     runs-on: ${{ matrix.platform.runner }}
@@ -61,9 +82,16 @@ jobs:
   github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: build-wheels
+    needs: [build-binary, build-wheels]
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download all binaries
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: binary-*
+          merge-multiple: true
 
       - name: Download all wheels
         uses: actions/download-artifact@v4
@@ -75,5 +103,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/*.whl
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
           generate_release_notes: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run test build clean install dev release lint format
+.PHONY: run test build clean install dev release release-test lint format
 
 # Development
 run:
@@ -41,4 +41,11 @@ release:
 		echo "Usage: make release TAG=vX.Y.Z"; \
 		exit 1; \
 	fi
-	gh release create "$(TAG)" --generate-notes
+	gh release create "$(TAG)" --target master --title "$(TAG)" --generate-notes
+
+release-test:
+	@if [ -z "$(TAG)" ]; then \
+		echo "Usage: make release-test TAG=vX.Y.Z-test.N [TARGET=branch-or-sha]"; \
+		exit 1; \
+	fi
+	gh release create "$(TAG)" --target "$(or $(TARGET),master)" --prerelease --title "$(TAG)" --generate-notes

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,11 @@ install:
 clean:
 	cargo clean
 	rm -rf target/ dist/ *.egg-info .pytest_cache/ .mypy_cache/ .ruff_cache/
+
+# Release
+release:
+	@if [ -z "$(TAG)" ]; then \
+		echo "Usage: make release TAG=vX.Y.Z"; \
+		exit 1; \
+	fi
+	gh release create "$(TAG)" --generate-notes


### PR DESCRIPTION
## Summary
- add \gh release create "vX.Y.Z" --generate-notes
https://github.com/Jakub3628800/pre-commit-template/releases/tag/vX.Y.Z as a thin wrapper around \
- remove release-binary build from branch CI
- build and attach Linux x86_64 binary artifact in tag-triggered release workflow

## Why
- keep binary builds tied to release tags
- provide a simple CLI wrapper for creating releases